### PR TITLE
change bentobox protection to check if players have access to chests …

### DIFF
--- a/src/main/java/com/artillexstudios/axsellwands/hooks/protection/BentoBoxHook.java
+++ b/src/main/java/com/artillexstudios/axsellwands/hooks/protection/BentoBoxHook.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.lists.Flags;
 
 import java.util.Optional;
 
@@ -13,6 +14,6 @@ public class BentoBoxHook implements ProtectionHook {
     public boolean canPlayerBuildAt(@NotNull Player player, @NotNull Location location) {
         final Optional<Island> is = BentoBox.getInstance().getIslands().getIslandAt(location);
 
-        return is.map(island -> island.getMemberSet().contains(player.getUniqueId())).orElse(true);
+        return is.map(island -> island.isAllowed(BentoBox.getInstance().getPlayers().getUser(player.getUniqueId()), Flags.CHEST)).orElse(false);
     }
 }


### PR DESCRIPTION
I've encountered some problems with how AxSellwands checks for Bentobox island members instead of doing a proper check of checking for chest access, so I've gone ahead and made that modification myself, since the members check is not accurate.

There are some cases in which when checking for island members doesn't return the Coop members of the island, so doing an actual check to see who has access to the chests is a better approach for this case.