### PR TITLE
Make sell wand destroy at zero uses

### DIFF
--- a/src/main/java/com/artillexstudios/axsellwands/listeners/SellwandUseListener.java
+++ b/src/main/java/com/artillexstudios/axsellwands/listeners/SellwandUseListener.java
@@ -156,7 +156,7 @@ public class SellwandUseListener implements Listener {
             if (uses != -1) {
                 uses--;
 
-                if (uses < 0) {
+                if (uses <= 0) {
                     event.getItem().setAmount(0);
                     return;
                 }


### PR DESCRIPTION
If you were to have a Sell Wand have 15 uses, you'd actually have 16 uses due to the logic 