### PR TITLE
feat(api): add sold-item map to AxSellwandsSellEvent

### DIFF
--- a/src/main/java/com/artillexstudios/axsellwands/api/events/AxSellwandsSellEvent.java
+++ b/src/main/java/com/artillexstudios/axsellwands/api/events/AxSellwandsSellEvent.java
@@ -1,10 +1,13 @@
 package com.artillexstudios.axsellwands.api.events;
 
+import org.bukkit.Material;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 public class AxSellwandsSellEvent extends Event implements Cancellable {
@@ -13,14 +16,21 @@ public class AxSellwandsSellEvent extends Event implements Cancellable {
     private double moneyMade;
     private final int itemsSold;
     private boolean isCancelled = false;
+    private final Map<Material, Integer> soldItems;
 
     public AxSellwandsSellEvent(@NotNull Player player, double moneyMade, int itemsSold) {
+        this(player, moneyMade, itemsSold, Collections.emptyMap());
+    }
+
+    public AxSellwandsSellEvent(@NotNull Player player, double moneyMade, int itemsSold, @NotNull Map<Material, Integer> soldItems) {
         super(!Bukkit.isPrimaryThread());
 
         this.player = player;
         this.moneyMade = moneyMade;
         this.itemsSold = itemsSold;
+        this.soldItems = soldItems;
     }
+
 
     @NotNull
     @Override
@@ -43,6 +53,11 @@ public class AxSellwandsSellEvent extends Event implements Cancellable {
 
     public int getItemsSold() {
         return itemsSold;
+    }
+
+    @NotNull
+    public Map<Material, Integer> getSoldItems() {
+        return Collections.unmodifiableMap(soldItems);
     }
 
     public void setMoneyMade(double moneyMade) {

--- a/src/main/java/com/artillexstudios/axsellwands/listeners/SellwandUseListener.java
+++ b/src/main/java/com/artillexstudios/axsellwands/listeners/SellwandUseListener.java
@@ -115,7 +115,7 @@ public class SellwandUseListener implements Listener {
                 return;
             }
 
-            AxSellwandsSellEvent apiEvent = new AxSellwandsSellEvent(player, newSoldPrice, newSoldAmount);
+            AxSellwandsSellEvent apiEvent = new AxSellwandsSellEvent(player, newSoldPrice, newSoldAmount, items);
             Bukkit.getPluginManager().callEvent(apiEvent);
             if (apiEvent.isCancelled()) return;
             newSoldPrice = apiEvent.getMoneyMade();


### PR DESCRIPTION
## Summary

This PR adds a per-`Material` breakdown of sold items to `AxSellwandsSellEvent`, so API consumers (other plugins, or scripting platforms like Denizen) can build sales statistics without having to re-implement the plugin's selling logic.

## Motivation

`AxSellwandsSellEvent` currently exposes the player, total money made, and total item count — but not *which* items were sold. This makes it impossible to track, for example, which materials are sold most frequently over time (useful for tuning shop prices).

The data already exists: `SellwandUseListener` builds a `Map<Material, Integer>` of exactly what was sold during each transaction, but it was discarded after the transaction instead of being passed to the event. Listening to `PlayerInteractEvent` externally doesn't help, since the event is fired *after* the items have already been removed (`it.setAmount(0)`), so by then the container is empty.

## Changes

- **`AxSellwandsSellEvent`**: Added a `Map<Material, Integer> soldItems` field with a `getSoldItems()` getter (returns an unmodifiable view). A new constructor accepts the breakdown; the existing constructor is kept and delegates to the new one with an empty map, so this is fully backwards-compatible.
- **`SellwandUseListener`**: Pass the already-computed `items` map into the event constructor.

## Notes

- Items are grouped by `Material` only, so NBT variants (enchantments, custom names, etc.) are merged. This is intentional and sufficient for the price-tuning use case.
- No behavioural change for existing consumers — the old constructor still works exactly as before.

## Possible follow-up

A per-`Material` price breakdown (`Map<Material, Double>`) would also be useful for price tuning, since revenue per item is more meaningful than raw quantity. I kept this PR focused on the quantity breakdown to keep it small and low-risk, but I'm happy to add it in a follow-up if you'd like.
